### PR TITLE
Mono fx update prove host to prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mono.co/prove-react-native",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0",
   "description": "The Mono Prove SDK is a quick and secure way to onboard your users from within your React Native app.",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 function createUrl(path: string, qs: any) {
-  let base = `https://develop.d121npziv08191.amplifyapp.com/${path}`;
+  let base = `https://prove.mono.co/${path}`;
 
   const queryParams = [];
   for (const k in qs) {


### PR DESCRIPTION
This PR updates the Prove host to `prove.mono.co` and bumps our alpha release to the first major version.